### PR TITLE
fix TECH-418 and MakeFile PATH for CentOS 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT=ssp
 SHELL=/bin/sh
-PATH=/usr/local/cpanel/3rdparty/perl/524/bin:/usr/local/cpanel/3rdparty/bin:/usr/sbin:/usr/bin
+PATH=/usr/local/cpanel/3rdparty/perl/524/bin:/usr/local/cpanel/3rdparty/bin:/sbin:/bin:/usr/sbin:/usr/bin
 PERLCRITIC=perlcritic
 PERLCRITICRC=tools/.perlcriticrc
 PERLTIDY=perltidy

--- a/ssp
+++ b/ssp
@@ -4272,14 +4272,15 @@ sub check_for_empty_easyapache_profiles {
         },
         $dir
     );
+    if (@easyapache_templates) {
+        my $templates;
+        for my $template (@easyapache_templates) {
+            $templates .= "$template ";
+        }
 
-    my $templates;
-    for my $template (@easyapache_templates) {
-        $templates .= "$template ";
+        print_warn("EA3 Empty template(s) in $dir: ");
+        print_warning($templates);
     }
-
-    print_warn("EA3 Empty template(s) in $dir: ");
-    print_warning($templates);
 }
 
 sub check_for_missing_timezone_from_phpini {

--- a/ssp
+++ b/ssp
@@ -33,7 +33,7 @@ use Cwd qw(abs_path);
 use Getopt::Long();
 
 # Application version (IMPORTANT! Increment this before submitting a pull request)
-our $VERSION = '4.99.173';
+our $VERSION = '4.99.174';
 
 # Global variables that alter application runtime
 our $opt_timeout;    # How long to wait for system commands to finish executing

--- a/ssp
+++ b/ssp
@@ -4273,13 +4273,8 @@ sub check_for_empty_easyapache_profiles {
         $dir
     );
     if (@easyapache_templates) {
-        my $templates;
-        for my $template (@easyapache_templates) {
-            $templates .= "$template ";
-        }
-
         print_warn("EA3 Empty template(s) in $dir: ");
-        print_warning($templates);
+        print_warning( join( ' ', @easyapache_templates ) );
     }
 }
 


### PR DESCRIPTION
Issue: 
1) This addresses case TECH-418
2) Fixes MakeFile PATH to work on CentOS 6

**Description**:
1) [WARN] * EA3 Empty template(s) in /var/cpanel/easy/apache/profile: Use of uninitialized value $text in concatenation (.) or string at - line 1475.

2) `# make tidy
-- Running perl syntax check
ssp syntax OK
-- Running perlcritic
ssp source OK
/bin/sh: egrep: command not found
cPanel perltidy not found!  Are you running this on a WHM 64+ system?
-- Running tidy
-- Checking if tidy
ssp is tidy.`

**Testing**: perlcritic: ✅  perltidy: ✅ 
No longer seeing this when no empty templates are present.
Seeing the warning when empty templates are present.