### PR TITLE
TECH-449 fix print_ea3_php_configuration php4 bin path assumption

### DIFF
--- a/ssp
+++ b/ssp
@@ -2045,16 +2045,18 @@ sub print_ea3_php_configuration {
         }
 
         if ( $EA3_PHP4HANDLER && $EA3_PHP4HANDLER ne 'none' ) {
-            my @php_v = split /\n/, timed_run( 0, '/usr/local/php4/bin/php', '-v' );
-            if ( @php_v && $php_v[0] =~ /^PHP\s(\S+)\s(\S+)/ ) {
-                $EA3_PHP4VERSION = $1;
-            }
-            else {
-                $EA3_PHP4VERSION = '(version unknown)';
-            }
+            if ( -x '/usr/local/php4/bin/php' ) {
+                my @php_v = split /\n/, timed_run( 0, '/usr/local/php4/bin/php', '-v' );
+                if ( @php_v && $php_v[0] =~ /^PHP\s(\S+)\s(\S+)/ ) {
+                    $EA3_PHP4VERSION = $1;
+                }
+                else {
+                    $EA3_PHP4VERSION = '(version unknown)';
+                }
 
-            print_info('PHP Secondary: ');
-            print_normal("PHP $EA3_PHP4VERSION $EA3_PHP4HANDLER $has_ea3_suexec");
+                print_info('PHP Secondary: ');
+                print_normal("PHP $EA3_PHP4VERSION $EA3_PHP4HANDLER $has_ea3_suexec");
+            }
         }
     }
 

--- a/ssp
+++ b/ssp
@@ -2051,7 +2051,7 @@ sub print_ea3_php_configuration {
                     $EA3_PHP4VERSION = $1;
                 }
                 else {
-                    $EA3_PHP4VERSION = '(version unknown)';
+                    $EA3_PHP4VERSION = '(ea3 php4 version unknown)';
                 }
 
                 print_info('PHP Secondary: ');

--- a/ssp
+++ b/ssp
@@ -34,7 +34,7 @@ use Cwd qw(abs_path);
 use Getopt::Long();
 
 # Application version (IMPORTANT! Increment this before submitting a pull request)
-our $VERSION = '4.99.177';
+our $VERSION = '4.99.178';
 
 # Global variables that alter application runtime
 our $OPT_TIMEOUT;    # How long to wait for system commands to finish executing


### PR DESCRIPTION
**Description**:
add ifblock execution test for /usr/local/php4/bin/php

**Issue**:
```
[INFO] * PHP Default: PHP 5.3.29 suphp with suexec
Use of uninitialized value in split at - line 2048.
[INFO] * PHP Secondary: PHP (version unknown) suphp with suexec
```

**Testing**:
perlcritic: ✅ 
perltidy: ✅
```-- Running perl syntax check
ssp syntax OK
-- Running perlcritic
ssp source OK
-- Running tidy
-- Checking if tidy
ssp is tidy.
```

Error is no longer present.