### PR TITLE
[TECH-494] Add documentation bug report Jira template

### DIFF
--- a/ssp
+++ b/ssp
@@ -35,7 +35,7 @@ use Getopt::Long();
 use Data::Dumper();
 
 # Application version (IMPORTANT! Increment this before submitting a pull request)
-our $VERSION = '4.99.180';
+our $VERSION = '4.99.181';
 
 # Global variables that alter application runtime
 our $OPT_TIMEOUT;    # How long to wait for system commands to finish executing

--- a/ssp
+++ b/ssp
@@ -217,10 +217,11 @@ sub init {
 
 sub run {
     local @ARGV = @_;    # Because GetOptionsFromArray available in Getopt::Long 2.36 and later only, Perl 5.8.8 on CentOS 5.11 includes 2.35
-    my ( $only_csi, $only_bugreport );
+    my ( $only_csi, $only_bugreport, $only_docreport );
 
     Getopt::Long::GetOptions(
         'bugreport' => \$only_bugreport,
+		'docreport' => \$only_docreport,
         'csi'       => \$only_csi,
         'timeout=i' => \$OPT_TIMEOUT,
     );
@@ -240,6 +241,7 @@ sub run {
 
     defined $only_csi       && exit csi_checks_only();
     defined $only_bugreport && exit print_bug_report();
+    defined $only_docreport && exit print_doc_bug_report();
 
     if ( -e '/var/cpanel/dnsonly' ) {
         dnsonly_checks_only();
@@ -8349,6 +8351,55 @@ Kernel: $kernel
 Arch: $arch
 Environment: $environment
 CPU: $cpu w/ $cores core(s)
+
+END_OF_TEMPLATE
+}
+
+sub print_doc_bug_report {
+    my $version     = $CPANEL_VERSION            ? $CPANEL_VERSION            : 'Unknown';
+    my $ticket      = "";
+    if ( defined $ENV{HISTFILE} and $ENV{HISTFILE} =~ /ticket.(\d+)$/ ) {
+        $ticket = $1;
+    }
+    print <<END_OF_TEMPLATE
+==== BEGIN COPY BELOW ====
+{panel:title=(i) Document and ticket URLS}
+   
+* Link to the document that requires modification.
+* Link to the support ticket that contains the relevant information.
+   
+{panel}
+   
+----
+   
+{panel:title=(+) Details}
+   
+Provide relevant information for any documentation changes.
+If this is a request for new documentation, provide an outline with the technical details required to complete the document.
+  
+   
+----
+   
+{panel:title=(?) Steps to reproduce}
+  
+Provide any technical steps required by the writer for the changes needed.
+   
+{panel}
+   
+----
+   
+{panel:title=(/) Additional Information}
+  
+  
+Any other useful information for the tech writer to complete the changes.
+   
+{panel}
+==== END COPY ABOVE ====
+
+Useful Information:
+
+Ticket Number: $ticket
+cPanel Version: $version
 
 END_OF_TEMPLATE
 }

--- a/ssp
+++ b/ssp
@@ -8364,35 +8364,36 @@ sub print_doc_bug_report {
     print <<END_OF_TEMPLATE
 ==== BEGIN COPY BELOW ====
 {panel:title=(i) Document and ticket URLS}
-   
+
 * Link to the document that requires modification.
 * Link to the support ticket that contains the relevant information.
-   
+
 {panel}
-   
+
 ----
-   
+
 {panel:title=(+) Details}
-   
+
 Provide relevant information for any documentation changes.
 If this is a request for new documentation, provide an outline with the technical details required to complete the document.
-  
-   
-----
-   
-{panel:title=(?) Steps to reproduce}
-  
-Provide any technical steps required by the writer for the changes needed.
-   
+
 {panel}
-   
+
 ----
-   
+
+{panel:title=(?) Steps to reproduce}
+
+Provide any technical steps required by the writer for the changes needed.
+
+{panel}
+
+----
+
 {panel:title=(/) Additional Information}
-  
-  
+
+
 Any other useful information for the tech writer to complete the changes.
-   
+
 {panel}
 ==== END COPY ABOVE ====
 

--- a/ssp
+++ b/ssp
@@ -221,7 +221,7 @@ sub run {
 
     Getopt::Long::GetOptions(
         'bugreport' => \$only_bugreport,
-		'docreport' => \$only_docreport,
+        'docreport' => \$only_docreport,
         'csi'       => \$only_csi,
         'timeout=i' => \$OPT_TIMEOUT,
     );
@@ -8356,8 +8356,8 @@ END_OF_TEMPLATE
 }
 
 sub print_doc_bug_report {
-    my $version     = $CPANEL_VERSION            ? $CPANEL_VERSION            : 'Unknown';
-    my $ticket      = "";
+    my $version = $CPANEL_VERSION ? $CPANEL_VERSION : 'Unknown';
+    my $ticket = "";
     if ( defined $ENV{HISTFILE} and $ENV{HISTFILE} =~ /ticket.(\d+)$/ ) {
         $ticket = $1;
     }


### PR DESCRIPTION
TS is now required to use a template when submitting documentation cases. This patch adds the option to specify --docreport, similar to --bugreport for printing the Jira documentation bug report template.