### PR TITLE
Fix whitespace issue from previous pull request

### DIFF
--- a/ssp
+++ b/ssp
@@ -3614,7 +3614,7 @@ sub check_for_hooks_in_scripts_directory {
 
     # default CloudLinux, cPGs hooks that can be ignored
     my %hooks_ignore = qw(
-      3035bcfdf629b8494bcd3dc933e97f30  /scripts/postkillacct 
+      3035bcfdf629b8494bcd3dc933e97f30  /scripts/postkillacct
       4988be925a6f50ec505618a7cec702e2  /scripts/postkillacct
       49e17847bdcb790fd30a1916427091b3  /scripts/postkillacct
       28620050548a2e4b500ab7426aaa0df5  /scripts/postmodifyacct


### PR DESCRIPTION
There were UTF "EN SPACE" used in the hooks_ignore hash in the previous pull request, resulting in
```
Odd number of elements in hash assignment at ssp line 3616.
```
I've fixed that up with some Real Spaces(TM) and removed the trailing whitespace.  I think this happened because the last commit of the pull was done on the github website?