### PR TITLE
[TECH-540] Add Puppet and SaltStack config management software detection

### DIFF
--- a/ssp
+++ b/ssp
@@ -35,7 +35,7 @@ use Getopt::Long();
 use Data::Dumper();
 
 # Application version (IMPORTANT! Increment this before submitting a pull request)
-our $VERSION = '4.99.179';
+our $VERSION = '4.99.188';
 
 # Global variables that alter application runtime
 our $OPT_TIMEOUT;    # How long to wait for system commands to finish executing
@@ -495,6 +495,9 @@ sub long_check_list {
     check_for_cron_allow();
     check_for_dev_sandbox();
     check_for_jail_owner();
+    check_sshd_config();
+    check_for_saltstack();
+    check_for_puppet_agent();
 
     # [3RDP]
     check_smtp_processes();
@@ -7552,6 +7555,17 @@ sub check_updatelog {
     }
 }
 
+sub check_for_saltstack {
+    return unless exists_process_cmd( qr{ salt-minion }xms, 'root' );
+    print_warn('SaltStack Minion: ');
+    print_warning('the salt-minion process is running. Seeing files being reverted, this may be why');
+}
+
+sub check_for_puppet_agent {
+    return unless exists_process_cmd( qr{ puppet }xms, 'root' );
+    print_warn('Puppet Agent: ');
+    print_warning('the puppet process is running. Seeing files being reverted, this may be why');
+}
 ##############################
 #  END [WARN] CHECKS
 ##############################


### PR DESCRIPTION
This change allows SSP to detect if Puppet or SaltStack is running on a host.