### PR TITLE
Add /etc/demousers content checks

### DIFF
--- a/ssp
+++ b/ssp
@@ -415,6 +415,7 @@ sub run {
     check_for_saltstack();
     check_for_puppet_agent();
     check_imunify360_running();
+    check_for_demo_users();
 
     # [3RDP]
     check_smtp_processes();

--- a/ssp
+++ b/ssp
@@ -7255,16 +7255,11 @@ sub check_for_puppet_agent {
 sub check_for_demo_users {
     my $demofile = '/etc/demousers';
     return unless -f $demofile;
-    open my $demofile_fh, '<', $demofile or return;
-    while (<$demofile_fh>) {
-        chomp;
-        if (/*/) {
-            print_warn('Demo users: ');
-            print_warning('/etc/demousers has content. If FTP is not working for a user, this may be why.');
-            last;
-        }
+    if (-s $demofile > 0) {
+        print_warn('Demo users: ');
+        print_warning('/etc/demousers has content. If FTP is not working for a user, this may be why.');
+        last;
     }
-    close $demofile_fh;
 }
 
 ##############################

--- a/ssp
+++ b/ssp
@@ -7250,6 +7250,22 @@ sub check_for_puppet_agent {
     print_warn('Puppet Agent: ');
     print_warning('the puppet process is running. Seeing files being reverted, this may be why');
 }
+
+sub check_for_demo_users {
+    my $demofile = '/etc/demousers';
+    return unless -f $demofile;
+    open my $demofile_fh, '<', $demofile or return;
+    while (<$demofile_fh>) {
+        chomp;
+        if (/*/) {
+            print_warn('Demo users: ');
+            print_warning('/etc/demousers has content. If FTP is not working for a user, this may be why.');
+            last;
+        }
+    }
+    close $demofile_fh;
+}
+
 ##############################
 #  END [WARN] CHECKS
 ##############################

--- a/ssp
+++ b/ssp
@@ -7258,7 +7258,6 @@ sub check_for_demo_users {
     if (-s $demofile > 0) {
         print_warn('Demo users: ');
         print_warning('/etc/demousers has content. If FTP is not working for a user, this may be why.');
-        last;
     }
 }
 


### PR DESCRIPTION
When a user is in /etc/demousers, FTP will not work. This is intentional, but for unfamiliar system administrators this may be unknown/confusing. This adds a warning that if the file exists and is larger than 0 bytes, it will list a warning.